### PR TITLE
fix: lone `<else />` making it not comply with specs

### DIFF
--- a/apalike.csl
+++ b/apalike.csl
@@ -149,7 +149,6 @@
           </else>
         </choose>
       </if>
-      <else/>
     </choose>
   </macro>
   <macro name="title">


### PR DESCRIPTION
I think that this was the reason you had this problem:
> It might send a warning regarding the standards. I really have no idea of what it is and that is why I am not trying to upload it to the Zotero official repo.

I don't know how it got there but the specification doesn't allow empty `else` branches and of course also not random closing tags without a corresponding opening tag.

This fixes both the warning in Zotero and makes it usable for other CSL 1.0.2 parsers like https://github.com/typst/citationberg.